### PR TITLE
Avoiding to send the cookie header on every request

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -46,5 +46,8 @@ ClassRegistry::addObject($options['LoaderAlias'], new SwivelLoader($options));
  */
 App::uses('CakeEventManager', 'Event');
 CakeEventManager::instance()->attach(function($event) use ($options) {
-	$event->data['response']->cookie($options['Cookie'] + ['value' => $options['BucketIndex']]);
+	$cookieName = $options['Cookie']['name'];
+	if (!isset($_COOKIE[$cookieName]) || $_COOKIE[$cookieName] != $options['BucketIndex']) {
+		$event->data['response']->cookie($options['Cookie'] + ['value' => $options['BucketIndex']]);
+	}
 }, 'Dispatcher.beforeDispatch');


### PR DESCRIPTION
The default configuration makes the cookie header being set on every request. Besides increasing the bandwidth, make the browser to reprocess the cookies. Also, and the most important fact, it also block caching tools to cache the page (if allowed). Most of the tools ignore the caching if any cache is being set.
