### PR TITLE
REQ-5119 // Let Swivel-Cake be configured to not set cookie

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -41,7 +41,7 @@ App::uses('ClassRegistry', 'Utility');
 App::uses('SwivelLoader', 'Swivel.Lib');
 ClassRegistry::addObject($options['LoaderAlias'], new SwivelLoader($options));
 
-if (!empty($options['Cookie'])) {
+if (!empty($options['Cookie']['enabled'])) {
     /**
      * Attach to Dispatcher.beforeDispatch event to set the cookie
      */

--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -41,13 +41,15 @@ App::uses('ClassRegistry', 'Utility');
 App::uses('SwivelLoader', 'Swivel.Lib');
 ClassRegistry::addObject($options['LoaderAlias'], new SwivelLoader($options));
 
-/**
- * Attach to Dispatcher.beforeDispatch event to set the cookie
- */
-App::uses('CakeEventManager', 'Event');
-CakeEventManager::instance()->attach(function ($event) use ($options) {
-    $cookieName = $options['Cookie']['name'];
-    if (!isset($_COOKIE[$cookieName]) || $_COOKIE[$cookieName] != $options['BucketIndex']) {
-        $event->data['response']->cookie($options['Cookie'] + ['value' => $options['BucketIndex']]);
-    }
-}, 'Dispatcher.beforeDispatch');
+if (!empty($options['Cookie'])) {
+    /**
+     * Attach to Dispatcher.beforeDispatch event to set the cookie
+     */
+    App::uses('CakeEventManager', 'Event');
+    CakeEventManager::instance()->attach(function ($event) use ($options) {
+        $cookieName = $options['Cookie']['name'];
+        if (!isset($_COOKIE[$cookieName]) || $_COOKIE[$cookieName] != $options['BucketIndex']) {
+            $event->data['response']->cookie($options['Cookie'] + ['value' => $options['BucketIndex']]);
+        }
+    }, 'Dispatcher.beforeDispatch');
+}

--- a/Config/default.php
+++ b/Config/default.php
@@ -3,6 +3,7 @@
 $config = [
     'Swivel' => [
         'Cookie' => [
+            'enabled' => true,
             'name' => 'Swivel_Bucket',
             'expire' => 0,
             'path' => '/',

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ buckets to your customers, you can do something like this:
 <?php
 
 // Saving bucket 1 for internal testing
-$bucketIndex = isset($\_COOKIE['Swivel\_Bucket']) ? $\_COOKIE['Swivel\_Bucket'] : mt_rand(2, 10);
+$bucketIndex = isset($_COOKIE['Swivel_Bucket']) ? $_COOKIE['Swivel_Bucket'] : mt_rand(2, 10);
 
 $config = [
     'Swivel' => [

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ some of the configurations.
 
 | Configuration | Default Value | Description |
 | ------------- | ------------- | ----------- |
-| Cookie        | (config below) | Set this to `null` to not set a cookie at all. Useful for APIs. |
+| Cookie.enabled | `true` | If cookie should be set at all |
 | Cookie.name   | `Swivel_Bucket` | Cookie name used to store the client bucket number. |
 | Cookie.expire | `0` | Expiration, in seconds, of the cookie. Setting 0 means a session cookie. |
 | Cookie.path | `/` | Cookie's path. |
@@ -55,21 +55,22 @@ want to override. Here is the default configuration file:
 <?php
 
 $config = [
-	'Swivel' => [
-		'Cookie' => [
-			'name' => 'Swivel_Bucket',
-			'expire' => 0,
-			'path' => '/',
-			'domain' => env('HTTP_HOST'),
-			'secure' => false,
-			'httpOnly' => false
-		],
-		'BucketIndex' => null,
-		'LoaderAlias' => 'SwivelManager',
-		'Logger' => null,
-		'Metrics' => null,
-		'ModelAlias' => 'Swivel.SwivelFeature',
-	]
+    'Swivel' => [
+        'Cookie' => [
+            'enabled' => true,
+            'name' => 'Swivel_Bucket',
+            'expire' => 0,
+            'path' => '/',
+            'domain' => env('HTTP_HOST'),
+            'secure' => false,
+            'httpOnly' => false
+        ],
+        'BucketIndex' => null,
+        'LoaderAlias' => 'SwivelManager',
+        'Logger' => null,
+        'Metrics' => null,
+        'ModelAlias' => 'Swivel.SwivelFeature',
+    ]
 ];
 ```
 
@@ -79,7 +80,7 @@ buckets to your customers, you can do something like this:
 <?php
 
 // Saving bucket 1 for internal testing
-$bucketIndex = isset($_COOKIE['Swivel_Bucket']) ? $_COOKIE['Swivel_Bucket'] : mt_rand(2, 10);
+$bucketIndex = isset($\_COOKIE['Swivel\_Bucket']) ? $\_COOKIE['Swivel\_Bucket'] : mt_rand(2, 10);
 
 $config = [
     'Swivel' => [

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ some of the configurations.
 
 | Configuration | Default Value | Description |
 | ------------- | ------------- | ----------- |
+| Cookie        | (config below) | Set this to `null` to not set a cookie at all. Useful for APIs. |
 | Cookie.name   | `Swivel_Bucket` | Cookie name used to store the client bucket number. |
 | Cookie.expire | `0` | Expiration, in seconds, of the cookie. Setting 0 means a session cookie. |
 | Cookie.path | `/` | Cookie's path. |


### PR DESCRIPTION
By setting `Cookie` to `null` in the configuration, we can now not set a cookie automatically. This is useful for APIs where setting cookies is not optimal.
