### PR TITLE
Added support to show diverged features

### DIFF
--- a/Lib/SwivelLoader/SwivelLoaderBuilderProxy.php
+++ b/Lib/SwivelLoader/SwivelLoaderBuilderProxy.php
@@ -1,0 +1,180 @@
+<?php
+
+App::uses('SwivelLoaderProxy', 'Swivel.Lib/SwivelLoader');
+
+final class SwivelLoaderBuilderProxy extends SwivelLoaderProxy implements \Zumba\Swivel\BuilderInterface {
+
+    /**
+     * Parent slug prefix
+     *
+     * @var string
+     */
+    private $prefix = '';
+
+    /**
+     * An array of feature slugs that have been proxied.
+     *
+     * @var array
+     */
+    private $slugs = [];
+
+    /**
+     * Swivel Loader
+     *
+     * @var SwivelLoader
+     */
+    protected $loader;
+
+    /**
+     * Creates a new BuilderProxy from a Swivel Builder.
+     *
+     * @param \Zumba\Swivel\BuilderInterface $builder
+     * @param SwivelLoader $loader
+     * @param string $slug
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public static function fromBuilder(\Zumba\Swivel\BuilderInterface $builder, SwivelLoader $loader, $slug) {
+        $proxy = new static($builder, $loader);
+        $proxy->setPrefix($slug);
+        return $proxy;
+    }
+
+    /**
+     * Swivel Builder Proxy
+     *
+     * Keeps track of what has been called on the swivel builder
+     *
+     * @param \Zumba\Swivel\BuilderInterface $builder
+     * @param SwivelLoader $loader
+     */
+    private function __construct(\Zumba\Swivel\BuilderInterface $builder, SwivelLoader $loader) {
+        $this->proxy = $builder;
+        $this->loader = $loader;
+    }
+
+    /**
+     * Add a behavior to be executed later.
+     *
+     * Behavior will only be added if it is enabled for the user's bucket.
+     *
+     * @param string $slug
+     * @param mixed  $strategy
+     * @param array  $args
+     *
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public function addBehavior($slug, $strategy, array $args = []) {
+        $this->proxy->addBehavior($slug, $strategy, $args);
+
+        $this->addSlug($slug);
+
+        return $this;
+    }
+
+    /**
+     * Add a value to be returned when the builder is executed.
+     *
+     * Value will only be returned if it is enabled for the user's bucket.
+     *
+     * @param string $slug
+     * @param mixed  $value
+     *
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public function addValue($slug, $value) {
+        $this->proxy->addValue($slug, $value);
+
+        $this->addSlug($slug);
+
+        return $this;
+    }
+
+    /**
+     * A fallback strategy if no added behaviors are active for the bucket.
+     *
+     * @param mixed $strategy
+     * @param array $args
+     *
+     * @return mixed
+     */
+    public function defaultBehavior($strategy, array $args = []) {
+        $this->proxy->defaultBehavior($strategy, $args);
+        return $this;
+    }
+
+    /**
+     * Creates a new Behavior object with an attached strategy.
+     *
+     * @param string $slug
+     * @param mixed  $strategy
+     *
+     * @return \Zumba\Swivel\Behavior
+     */
+    public function getBehavior($slug, $strategy = null) {
+        $this->proxy->getBehavior($slug, $strategy);
+        return $this;
+    }
+
+    /**
+     * Indicates that the feature has no default behavior.
+     *
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public function noDefault() {
+        $this->proxy->noDefault();
+        return $this;
+    }
+
+    /**
+     * Execute the feature and return the result of the behavior.
+     *
+     * @return mixed
+     */
+    public function execute() {
+        $result = $this->proxy->execute();
+        $slugs = array_unique($this->slugs);
+        array_walk($slugs, [$this->loader, 'recordSlug']);
+        return $result;
+    }
+
+    /**
+     * Set a metrics object.
+     *
+     * @param \Zumba\Swivel\MetricsInterface $metrics
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public function setMetrics(\Zumba\Swivel\MetricsInterface $metrics) {
+        $this->proxy->setMetrics($metrics);
+        return $this;
+    }
+
+    /**
+     * Sets a logger.
+     *
+     * @param \Psr\Log\LoggerInterface $logger
+     * @return void
+     */
+    public function setLogger(\Psr\Log\LoggerInterface $logger) {
+        $this->proxy->setLogger($logger);
+    }
+
+    /**
+     * Set the prefix property
+     *
+     * @param string $slug
+     * @return void
+     */
+    private function setPrefix($slug) {
+        $this->prefix = $slug . '.';
+    }
+
+    /**
+     * Add a prefixed slug to the slugs array
+     *
+     * @param string $slug
+     * @return void
+     */
+    private function addSlug($slug) {
+        $this->slugs[] = $this->prefix . $slug;
+    }
+}

--- a/Lib/SwivelLoader/SwivelLoaderManagerProxy.php
+++ b/Lib/SwivelLoader/SwivelLoaderManagerProxy.php
@@ -1,0 +1,105 @@
+<?php
+
+App::uses('SwivelLoaderProxy', 'Swivel.Lib/SwivelLoader');
+App::uses('SwivelLoaderBuilderProxy', 'Swivel.Lib/SwivelLoader');
+
+final class SwivelLoaderManagerProxy extends SwivelLoaderProxy implements \Zumba\Swivel\ManagerInterface {
+
+    /**
+     * Swivel Loader
+     *
+     * @var SwivelLoader
+     */
+    protected $loader;
+
+    /**
+     * Creates a new ManagerProxy from a Swivel Manager.
+     *
+     * @param \Zumba\Swivel\ManagerInterface $manager
+     * @param SwivelLoader $loader
+     * @return \Zumba\Swivel\ManagerInterface
+     */
+    public static function fromManager(\Zumba\Swivel\ManagerInterface $manager, SwivelLoader $loader) {
+        return new static($manager, $loader);
+    }
+
+    /**
+     * Swivel Manager Proxy
+     *
+     * Keeps track of what has been called on the swivel manager
+     * and wraps swivel builders with Builder Proxy objects
+     *
+     * @param \Zumba\Swivel\ManagerInterface $manager
+     * @param SwivelLoader $loader
+     */
+    private function __construct(\Zumba\Swivel\ManagerInterface $manager, SwivelLoader $loader) {
+        $this->proxy = $manager;
+        $this->loader = $loader;
+    }
+
+    /**
+     * Create a new Builder Proxy instance.
+     *
+     * @param string $slug
+     *
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public function forFeature($slug) {
+        return SwivelLoaderBuilderProxy::fromBuilder($this->proxy->forFeature($slug), $this->loader, $slug);
+    }
+
+    /**
+     * Syntactic sugar for creating simple feature toggles (ternary style).
+     *
+     * @param string $slug
+     * @param mixed  $a
+     * @param mixed  $b
+     *
+     * @return mixed
+     */
+    public function invoke($slug, $a, $b = null) {
+        $result = $this->proxy->invoke($slug, $a, $b);
+        $this->loader->recordSlug($slug);
+        return $result;
+    }
+
+    /**
+     * Syntactic sugar for creating simple feature toggles (ternary style).
+     *
+     * Uses Builder::addValue
+     *
+     * @param string $slug
+     * @param mixed  $a
+     * @param mixed  $b
+     *
+     * @return mixed
+     *
+     * @see \Zumba\Swivel\ManagerInterface
+     */
+    public function returnValue($slug, $a, $b = null) {
+        $result = $this->proxy->returnValue($slug, $a, $b);
+        $this->loader->recordSlug($slug);
+        return $result;
+    }
+
+    /**
+     * Set the Swivel Bucket.
+     *
+     * @param \Zumba\Swivel\BucketInterface $bucket
+     *
+     * @return \Zumba\Swivel\ManagerInterface
+     */
+    public function setBucket(\Zumba\Swivel\BucketInterface $bucket = null) {
+        return $this->proxy->setBucket($bucket);
+    }
+
+    /**
+     * Sets a logger.
+     *
+     * @param \Psr\Log\LoggerInterface $logger
+     * @return void
+     */
+    public function setLogger(\Psr\Log\LoggerInterface $logger) {
+        $this->proxy->setLogger($logger);
+    }
+}

--- a/Lib/SwivelLoader/SwivelLoaderProxy.php
+++ b/Lib/SwivelLoader/SwivelLoaderProxy.php
@@ -1,0 +1,23 @@
+<?php
+
+abstract class SwivelLoaderProxy {
+
+    /**
+     * A swivel object to be proxied.
+     *
+     * @var mixed
+     */
+    protected $proxy;
+
+    /**
+     * Proxy calls to the swivel object that don't need to be tracked.
+     *
+     * @param string $name
+     * @param array $arguments
+     * @return mixed
+     */
+    public function __call($name, $arguments) {
+        call_user_func_array([ $this->proxy, $name ], $arguments);
+        return $this;
+    }
+}


### PR DESCRIPTION
The diverged features are features that are not all active or inactive on all buckets. With this change, the apps can determine if the page has variations and properly vary the cache.