### PR TITLE
Bumping Swivel version to 2.1.x

### DIFF
--- a/Controller/Component/SwivelComponent.php
+++ b/Controller/Component/SwivelComponent.php
@@ -36,9 +36,9 @@ class SwivelComponent extends Component
     /**
      * Syntactic sugar for creating simple feature toggles (ternary style)
      *
-     * @param string $slug
-     * @param mixed $a
-     * @param mixed $b
+     * @param string    $slug
+     * @param callable  $a
+     * @param callable  $b
      * @return mixed
      */
     public function invoke($slug, $a, $b = null)

--- a/Lib/SwivelLoader/SwivelLoaderBuilderProxy.php
+++ b/Lib/SwivelLoader/SwivelLoaderBuilderProxy.php
@@ -57,9 +57,9 @@ final class SwivelLoaderBuilderProxy extends SwivelLoaderProxy implements \Zumba
      *
      * Behavior will only be added if it is enabled for the user's bucket.
      *
-     * @param string $slug
-     * @param mixed  $strategy
-     * @param array  $args
+     * @param string    $slug
+     * @param callable  $strategy
+     * @param array     $args
      *
      * @return \Zumba\Swivel\BuilderInterface
      */
@@ -92,8 +92,8 @@ final class SwivelLoaderBuilderProxy extends SwivelLoaderProxy implements \Zumba
     /**
      * A fallback strategy if no added behaviors are active for the bucket.
      *
-     * @param mixed $strategy
-     * @param array $args
+     * @param callable  $strategy
+     * @param array     $args
      *
      * @return mixed
      */
@@ -105,8 +105,8 @@ final class SwivelLoaderBuilderProxy extends SwivelLoaderProxy implements \Zumba
     /**
      * Creates a new Behavior object with an attached strategy.
      *
-     * @param string $slug
-     * @param mixed  $strategy
+     * @param string    $slug
+     * @param callable  $strategy
      *
      * @return \Zumba\Swivel\Behavior
      */

--- a/Lib/SwivelLoader/SwivelLoaderManagerProxy.php
+++ b/Lib/SwivelLoader/SwivelLoaderManagerProxy.php
@@ -51,9 +51,9 @@ final class SwivelLoaderManagerProxy extends SwivelLoaderProxy implements \Zumba
     /**
      * Syntactic sugar for creating simple feature toggles (ternary style).
      *
-     * @param string $slug
-     * @param mixed  $a
-     * @param mixed  $b
+     * @param string    $slug
+     * @param callable  $a
+     * @param callable  $b
      *
      * @return mixed
      */

--- a/Model/Behavior/SwivelableBehavior.php
+++ b/Model/Behavior/SwivelableBehavior.php
@@ -38,9 +38,9 @@ class SwivelableBehavior extends ModelBehavior
      * Syntactic sugar for creating simple feature toggles (ternary style)
      *
      * @param Model $model
-     * @param string $slug
-     * @param mixed $a
-     * @param mixed $b
+     * @param string    $slug
+     * @param callable  $a
+     * @param callable  $b
      * @return mixed
      */
     public function invoke(Model $model, $slug, $a, $b = null)

--- a/View/Helper/SwivelHelper.php
+++ b/View/Helper/SwivelHelper.php
@@ -39,9 +39,9 @@ class SwivelHelper extends AppHelper
     /**
      * Syntactic sugar for creating simple feature toggles (ternary style)
      *
-     * @param string $slug
-     * @param mixed $a
-     * @param mixed $b
+     * @param string    $slug
+     * @param callable  $a
+     * @param callable  $b
      * @return mixed
      */
     public function invoke($slug, $a, $b = null)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": ">=5.4",
 		"composer/installers": "1.0.*",
-		"zumba/swivel": "1.3.*"
+		"zumba/swivel": "2.1.*"
 	},
 	"support": {
 		"source": "https://github.com/zumba/swivel-cake"

--- a/composer.lock
+++ b/composer.lock
@@ -4,22 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a72f982d1c4cb0297529aa7483df997b",
-    "content-hash": "41544895c9bc30de49c44a63b25d1e89",
+    "content-hash": "b931b620c266accfbb151a3385f7bbf9",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.0.21",
+            "version": "v1.0.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "d64e23fce42a4063d63262b19b8e7c0f3b5e4c45"
+                "reference": "36e5b5843203d7f1cf6ffb0305a97e014387bd8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/d64e23fce42a4063d63262b19b8e7c0f3b5e4c45",
-                "reference": "d64e23fce42a4063d63262b19b8e7c0f3b5e4c45",
+                "url": "https://api.github.com/repos/composer/installers/zipball/36e5b5843203d7f1cf6ffb0305a97e014387bd8e",
+                "reference": "36e5b5843203d7f1cf6ffb0305a97e014387bd8e",
                 "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
@@ -29,16 +31,16 @@
                 "composer/composer": "1.0.*@dev",
                 "phpunit/phpunit": "4.1.*"
             },
-            "type": "composer-installer",
+            "type": "composer-plugin",
             "extra": {
-                "class": "Composer\\Installers\\Installer",
+                "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
                     "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Composer\\Installers\\": "src/"
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -53,12 +55,14 @@
                 }
             ],
             "description": "A multi-framework Composer library installer",
-            "homepage": "http://composer.github.com/installers/",
+            "homepage": "https://composer.github.io/installers/",
             "keywords": [
                 "Craft",
                 "Dolibarr",
                 "Hurad",
+                "ImageCMS",
                 "MODX Evo",
+                "Mautic",
                 "OXID",
                 "SMF",
                 "Thelia",
@@ -100,26 +104,34 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2015-02-18 17:17:01"
+            "time": "2016-04-13T19:46:30+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -133,25 +145,26 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "zumba/swivel",
-            "version": "v1.3.1",
+            "version": "v2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zumba/swivel.git",
-                "reference": "58cd195b43f96c10a6f7d46f7ad1d088e94ee659"
+                "reference": "eef2b3ccb23a37f38c6126b227dbe90420edb387"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zumba/swivel/zipball/58cd195b43f96c10a6f7d46f7ad1d088e94ee659",
-                "reference": "58cd195b43f96c10a6f7d46f7ad1d088e94ee659",
+                "url": "https://api.github.com/repos/zumba/swivel/zipball/eef2b3ccb23a37f38c6126b227dbe90420edb387",
+                "reference": "eef2b3ccb23a37f38c6126b227dbe90420edb387",
                 "shasum": ""
             },
             "require": {
@@ -160,8 +173,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "4.4.*",
-                "satooshi/php-coveralls": "dev-master",
-                "zumba/zumba-coding-standards": "~1.0"
+                "squizlabs/php_codesniffer": "2.6.*"
             },
             "type": "library",
             "autoload": {
@@ -191,7 +203,7 @@
                 "strategy",
                 "toggle"
             ],
-            "time": "2016-12-13 18:17:12"
+            "time": "2017-09-18T18:51:07+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This PR is intended to use the latest Swivel version and the new restrictions applied. Taking into consideration that Swivel 2.x forces the behavior to be a callable, the documentation for this plugin has been updated too.

**Proposal:** 
From now on, commits on this branch should be pushed to 2.x tags